### PR TITLE
Add adhoc-bin-rle mode to benchmark and visualization scripts

### DIFF
--- a/scripts/benchmark_insitu_vs_adhoc.py
+++ b/scripts/benchmark_insitu_vs_adhoc.py
@@ -104,6 +104,9 @@ def run_benchmark(
     elif mode == 'adhoc-bin':
         os.makedirs(snapshot_dir, exist_ok=True)
         cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-format", "bin"])
+    elif mode == 'adhoc-bin-rle':
+        os.makedirs(snapshot_dir, exist_ok=True)
+        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-format", "bin", "--snapshot-rle"])
     elif mode == 'insitu':
         os.makedirs(snapshot_dir, exist_ok=True)
         cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-in-situ"])
@@ -256,9 +259,9 @@ def main():
     parser.add_argument(
         "--modes", "-m",
         nargs="+",
-        choices=["base", "adhoc-plain", "adhoc-bin", "insitu", "rgb"],
-        default=["base", "adhoc-plain", "adhoc-bin", "insitu", "rgb"],
-        help="Export modes to benchmark: base (no snapshots), adhoc-plain (plain text), adhoc-bin (binary), insitu (image), rgb (colormap) (default: base adhoc-plain adhoc-bin insitu rgb)"
+        choices=["base", "adhoc-plain", "adhoc-bin", "adhoc-bin-rle", "insitu", "rgb"],
+        default=["base", "adhoc-plain", "adhoc-bin", "adhoc-bin-rle", "insitu", "rgb"],
+        help="Export modes to benchmark: base (no snapshots), adhoc-plain (plain text), adhoc-bin (binary), adhoc-bin-rle (binary with RLE), insitu (image), rgb (colormap) (default: all)"
     )
     parser.add_argument(
         "--sizes", "-s",

--- a/scripts/plot_benchmark.py
+++ b/scripts/plot_benchmark.py
@@ -13,6 +13,7 @@ MODE_STYLES = {
     'base': {'color': '#2c3e50', 'marker': 'o', 'linestyle': '-'},
     'adhoc-plain': {'color': '#e74c3c', 'marker': 's', 'linestyle': '-'},
     'adhoc-bin': {'color': '#c0392b', 'marker': 'p', 'linestyle': '-.'},
+    'adhoc-bin-rle': {'color': '#8e44ad', 'marker': 'h', 'linestyle': '-.'},
     'insitu': {'color': '#3498db', 'marker': '^', 'linestyle': '--'},
     'rgb': {'color': '#27ae60', 'marker': 'D', 'linestyle': ':'},
 }
@@ -21,6 +22,7 @@ MODE_LABELS = {
     'base': 'Base (no export)',
     'adhoc-plain': 'Ad-hoc (plain text)',
     'adhoc-bin': 'Ad-hoc (binary)',
+    'adhoc-bin-rle': 'Ad-hoc (binary RLE)',
     'insitu': 'In-situ (grayscale)',
     'rgb': 'In-situ (RGB colormap)',
 }
@@ -93,7 +95,7 @@ def main():
     breakdown = grouped[grouped['grid_total'] == largest_grid][['mode', 'time_simulating', 'time_snapshots', 'time_sismos']]
     breakdown = breakdown.set_index('mode')
     # Reorder index to match our preferred order
-    order = [m for m in ['base', 'adhoc-plain', 'adhoc-bin', 'insitu', 'rgb'] if m in breakdown.index]
+    order = [m for m in ['base', 'adhoc-plain', 'adhoc-bin', 'adhoc-bin-rle', 'insitu', 'rgb'] if m in breakdown.index]
     breakdown = breakdown.reindex(order)
     breakdown.index = [get_label(m) for m in breakdown.index]
     breakdown.plot(kind='bar', stacked=True, ax=ax, color=['#3498db', '#e74c3c', '#f39c12'])


### PR DESCRIPTION
- Add 'adhoc-bin-rle' mode to benchmark script choices
- Add command-line arguments for --snapshot-rle flag
- Add styling and labels for RLE mode in plot script
- Update bar chart ordering to include RLE mode