### PR TITLE
Add quantization support to benchmark and plotting scripts

### DIFF
--- a/scripts/benchmark_compression.py
+++ b/scripts/benchmark_compression.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 """
-Benchmark script to compare ad-hoc vs in-situ export approaches for HPC simulation.
+Benchmark script to compare RLE compression vs no compression for binary snapshots.
 
-This script runs the SEM simulation with different configurations and grid sizes,
-collecting timing metrics and data output statistics for analysis.
+This script focuses on comparing:
+- adhoc-bin: Binary snapshots without compression
+- adhoc-bin-rle: Binary snapshots with RLE compression
+
+Metrics collected:
+- Execution time (simulation, snapshots, total)
+- Total data exported (bytes)
 """
 
 import argparse
@@ -30,7 +35,7 @@ TIME_KERNEL_TOTAL_REGEX = rf"Time Kernel Total : {NUMBER_REGEX} seconds\."
 @dataclass
 class BenchmarkResult:
     """Holds the results of a single benchmark run."""
-    mode: str
+    compression: str  # 'none' or 'rle'
     ex: int
     ey: int
     ez: int
@@ -65,7 +70,7 @@ def parse_output(output: str) -> dict:
 
 def run_benchmark(
     bin_path: str,
-    mode: str,
+    compression: str,
     ex: int,
     ey: int,
     ez: int,
@@ -77,7 +82,7 @@ def run_benchmark(
 
     Args:
         bin_path: Path to the semproxy executable
-        mode: Export mode - 'insitu' or 'adhoc'
+        compression: Compression mode ('none', 'rle', 'quant1', 'quant2', 'quant1_rle', 'quant2_rle')
         ex, ey, ez: Grid dimensions
         timemax: Maximum simulation time
         output_dir: Directory for temporary output files
@@ -85,46 +90,30 @@ def run_benchmark(
     Returns:
         BenchmarkResult if successful, None otherwise
     """
-    snapshot_dir = os.path.join(output_dir, f"snapshots_{mode}_{ex}x{ey}x{ez}")
+    snapshot_dir = os.path.join(output_dir, f"snapshots_{compression}_{ex}x{ey}x{ez}")
+    os.makedirs(snapshot_dir, exist_ok=True)
 
-    # Build command based on mode
+    # Build command
     cmd = [
         bin_path,
         "--ex", str(ex),
         "--ey", str(ey),
         "--ez", str(ez),
         "--timemax", str(timemax),
+        "--snapshot-folder-path", snapshot_dir,
+        "--snapshot-format", "bin",
     ]
 
-    if mode == 'base':
-        pass  # No snapshot arguments
-    elif mode == 'adhoc-plain':
-        os.makedirs(snapshot_dir, exist_ok=True)
-        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-format", "plain"])
-    elif mode == 'adhoc-bin':
-        os.makedirs(snapshot_dir, exist_ok=True)
-        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-format", "bin"])
-    elif mode == 'adhoc-bin-rle':
-        os.makedirs(snapshot_dir, exist_ok=True)
-        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-format", "bin", "--snapshot-rle"])
-    elif mode == 'adhoc-bin-quant1':
-        os.makedirs(snapshot_dir, exist_ok=True)
-        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-format", "bin", "--compression", "quant", "--quant-level", "1"])
-    elif mode == 'adhoc-bin-quant2':
-        os.makedirs(snapshot_dir, exist_ok=True)
-        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-format", "bin", "--compression", "quant", "--quant-level", "2"])
-    elif mode == 'adhoc-bin-quant1-rle':
-        os.makedirs(snapshot_dir, exist_ok=True)
-        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-format", "bin", "--compression", "quant_rle", "--quant-level", "1"])
-    elif mode == 'adhoc-bin-quant2-rle':
-        os.makedirs(snapshot_dir, exist_ok=True)
-        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-format", "bin", "--compression", "quant_rle", "--quant-level", "2"])
-    elif mode == 'insitu':
-        os.makedirs(snapshot_dir, exist_ok=True)
-        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-in-situ"])
-    elif mode == 'rgb':
-        os.makedirs(snapshot_dir, exist_ok=True)
-        cmd.extend(["--snapshot-folder-path", snapshot_dir, "--snapshot-in-situ", "--snapshot-colormap", "viridis"])
+    if compression == 'rle':
+        cmd.append("--snapshot-rle")
+    elif compression == 'quant1':
+        cmd.extend(["--compression", "quant", "--quant-level", "1"])
+    elif compression == 'quant2':
+        cmd.extend(["--compression", "quant", "--quant-level", "2"])
+    elif compression == 'quant1_rle':
+        cmd.extend(["--compression", "quant_rle", "--quant-level", "1"])
+    elif compression == 'quant2_rle':
+        cmd.extend(["--compression", "quant_rle", "--quant-level", "2"])
 
     print(f"  Running: {' '.join(cmd)}")
 
@@ -145,7 +134,7 @@ def run_benchmark(
         metrics = parse_output(output)
 
         return BenchmarkResult(
-            mode=mode,
+            compression=compression,
             ex=ex,
             ey=ey,
             ez=ez,
@@ -170,18 +159,18 @@ def run_benchmark(
 
 def run_benchmarks(
     bin_path: str,
-    modes: list[str],
+    compressions: list[str],
     grid_sizes: list[tuple[int, int, int]],
     timemax: float,
     output_dir: str,
     num_runs: int = 1,
 ) -> list[BenchmarkResult]:
     """
-    Run benchmarks for all combinations of modes and grid sizes.
+    Run benchmarks for all combinations of compression modes and grid sizes.
 
     Args:
         bin_path: Path to the semproxy executable
-        modes: List of export modes to test
+        compressions: List of compression modes to test
         grid_sizes: List of (ex, ey, ez) tuples
         timemax: Maximum simulation time
         output_dir: Directory for temporary output files
@@ -191,17 +180,17 @@ def run_benchmarks(
         List of BenchmarkResult objects
     """
     results = []
-    total_configs = len(modes) * len(grid_sizes) * num_runs
+    total_configs = len(compressions) * len(grid_sizes) * num_runs
     current = 0
 
-    for mode, (ex, ey, ez) in itertools.product(modes, grid_sizes):
+    for compression, (ex, ey, ez) in itertools.product(compressions, grid_sizes):
         for run_idx in range(num_runs):
             current += 1
-            print(f"[{current}/{total_configs}] Mode: {mode}, Grid: {ex}x{ey}x{ez}, Run: {run_idx + 1}/{num_runs}")
+            print(f"[{current}/{total_configs}] Compression: {compression}, Grid: {ex}x{ey}x{ez}, Run: {run_idx + 1}/{num_runs}")
 
             result = run_benchmark(
                 bin_path=bin_path,
-                mode=mode,
+                compression=compression,
                 ex=ex,
                 ey=ey,
                 ez=ez,
@@ -213,7 +202,8 @@ def run_benchmarks(
                 results.append(result)
                 print(f"    Simulating: {result.time_simulating:.4f}s, "
                       f"Snapshots: {result.time_snapshots:.4f}s, "
-                      f"Bytes: {result.total_bytes:.0f}")
+                      f"Total: {result.time_kernel_total:.4f}s, "
+                      f"Data: {result.total_bytes / 1024 / 1024:.2f} MB")
             else:
                 print(f"    FAILED")
 
@@ -223,9 +213,9 @@ def run_benchmarks(
 def save_results_csv(results: list[BenchmarkResult], output_path: str):
     """Save benchmark results to a CSV file."""
     fieldnames = [
-        'mode', 'ex', 'ey', 'ez', 'grid_total',
+        'compression', 'ex', 'ey', 'ez', 'grid_total',
         'time_simulating', 'time_snapshots', 'time_sismos',
-        'time_kernel_total', 'total_bytes',
+        'time_kernel_total', 'total_bytes', 'total_mb',
     ]
 
     with open(output_path, 'w', newline='') as f:
@@ -234,7 +224,7 @@ def save_results_csv(results: list[BenchmarkResult], output_path: str):
 
         for r in results:
             writer.writerow({
-                'mode': r.mode,
+                'compression': r.compression,
                 'ex': r.ex,
                 'ey': r.ey,
                 'ez': r.ez,
@@ -244,14 +234,60 @@ def save_results_csv(results: list[BenchmarkResult], output_path: str):
                 'time_sismos': r.time_sismos,
                 'time_kernel_total': r.time_kernel_total,
                 'total_bytes': r.total_bytes,
+                'total_mb': r.total_bytes / 1024 / 1024,
             })
 
-    print(f"Results saved to {output_path}")
+    print(f"\nResults saved to {output_path}")
+
+
+def print_summary(results: list[BenchmarkResult]):
+    """Print a summary comparison of all compression modes."""
+    if not results:
+        return
+
+    print("\n" + "="*80)
+    print("SUMMARY: Compression Comparison")
+    print("="*80)
+
+    # Group by grid size
+    grid_sizes = sorted(set((r.ex, r.ey, r.ez) for r in results))
+    compression_modes = sorted(set(r.compression for r in results))
+
+    for ex, ey, ez in grid_sizes:
+        grid_results = [r for r in results if (r.ex, r.ey, r.ez) == (ex, ey, ez)]
+
+        # Get baseline (no compression)
+        none_results = [r for r in grid_results if r.compression == 'none']
+        if not none_results:
+            continue
+
+        none_time = sum(r.time_kernel_total for r in none_results) / len(none_results)
+        none_bytes = sum(r.total_bytes for r in none_results) / len(none_results)
+
+        print(f"\nGrid {ex}x{ey}x{ez} ({ex*ey*ez} elements):")
+        print(f"  {'Mode':<20} {'Time (s)':<12} {'Ratio':<10} {'Data (MB)':<12} {'Compression':<12} {'Reduction':<10}")
+        print(f"  {'-'*20} {'-'*12} {'-'*10} {'-'*12} {'-'*12} {'-'*10}")
+
+        for mode in compression_modes:
+            mode_results = [r for r in grid_results if r.compression == mode]
+            if not mode_results:
+                continue
+
+            mode_time = sum(r.time_kernel_total for r in mode_results) / len(mode_results)
+            mode_bytes = sum(r.total_bytes for r in mode_results) / len(mode_results)
+
+            time_ratio = mode_time / none_time if none_time > 0 else 0
+            compression_ratio = mode_bytes / none_bytes if none_bytes > 0 else 0
+            reduction = (1 - compression_ratio) * 100
+
+            print(f"  {mode:<20} {mode_time:<12.4f} {time_ratio:<10.2f} {mode_bytes/1024/1024:<12.2f} {compression_ratio:<12.2f} {reduction:<10.1f}%")
+
+    print("="*80)
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Benchmark in-situ vs ad-hoc export approaches for HPC simulation"
+        description="Benchmark compression methods for binary snapshots"
     )
     parser.add_argument(
         "--bin", "-b",
@@ -261,26 +297,26 @@ def main():
     parser.add_argument(
         "--output", "-o",
         default=None,
-        help="Output CSV file path (default: benchmark_TIMESTAMP.csv)"
+        help="Output CSV file path (default: benchmark_compression_TIMESTAMP.csv)"
     )
     parser.add_argument(
         "--output-dir",
-        default="./benchmark_tmp",
-        help="Directory for temporary output files (default: ./benchmark_tmp)"
+        default="./benchmark_compression_tmp",
+        help="Directory for temporary output files (default: ./benchmark_compression_tmp)"
     )
     parser.add_argument(
-        "--modes", "-m",
+        "--compressions", "-c",
         nargs="+",
-        choices=["base", "adhoc-plain", "adhoc-bin", "adhoc-bin-rle", "adhoc-bin-quant1", "adhoc-bin-quant2", "adhoc-bin-quant1-rle", "adhoc-bin-quant2-rle", "insitu", "rgb"],
-        default=["base", "adhoc-plain", "adhoc-bin", "adhoc-bin-rle", "adhoc-bin-quant1", "adhoc-bin-quant2", "adhoc-bin-quant1-rle", "adhoc-bin-quant2-rle", "insitu", "rgb"],
-        help="Export modes to benchmark: base (no snapshots), adhoc-plain (plain text), adhoc-bin (binary), adhoc-bin-rle (binary with RLE), adhoc-bin-quant1/2 (binary with quantization), adhoc-bin-quant1/2-rle (quantization + RLE), insitu (image), rgb (colormap) (default: all)"
+        choices=["none", "rle", "quant1", "quant2", "quant1_rle", "quant2_rle"],
+        default=["none", "rle", "quant1", "quant2", "quant1_rle", "quant2_rle"],
+        help="Compression modes to test (default: all)"
     )
     parser.add_argument(
         "--sizes", "-s",
         nargs="+",
         type=int,
-        default=[10, 20, 30, 40, 50],
-        help="Grid sizes to test (same for ex, ey, ez) (default: 10 20 30 40 50)"
+        default=[10, 20, 30, 40, 50, 75, 100, 125, 150],
+        help="Grid sizes to test (same for ex, ey, ez) (default: 10 20 30 40 50 75 100 125 150)"
     )
     parser.add_argument(
         "--timemax", "-t",
@@ -291,8 +327,8 @@ def main():
     parser.add_argument(
         "--runs", "-r",
         type=int,
-        default=1,
-        help="Number of runs per configuration (default: 1)"
+        default=3,
+        help="Number of runs per configuration for averaging (default: 3)"
     )
 
     args = parser.parse_args()
@@ -311,11 +347,11 @@ def main():
     # Set output filename
     if args.output is None:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        args.output = f"benchmark_{timestamp}.csv"
+        args.output = f"benchmark_compression_{timestamp}.csv"
 
-    print(f"\nBenchmark Configuration:")
+    print(f"\nCompression Benchmark Configuration:")
     print(f"  Binary: {args.bin}")
-    print(f"  Modes: {args.modes}")
+    print(f"  Compression modes: {args.compressions}")
     print(f"  Grid sizes: {grid_sizes}")
     print(f"  Timemax: {args.timemax}s")
     print(f"  Runs per config: {args.runs}")
@@ -325,7 +361,7 @@ def main():
     # Run benchmarks
     results = run_benchmarks(
         bin_path=args.bin,
-        modes=args.modes,
+        compressions=args.compressions,
         grid_sizes=grid_sizes,
         timemax=args.timemax,
         output_dir=args.output_dir,
@@ -338,6 +374,9 @@ def main():
 
     # Save results
     save_results_csv(results, args.output)
+
+    # Print summary
+    print_summary(results)
 
     # Cleanup
     if os.path.exists(args.output_dir):

--- a/scripts/plot_benchmark.py
+++ b/scripts/plot_benchmark.py
@@ -14,6 +14,10 @@ MODE_STYLES = {
     'adhoc-plain': {'color': '#e74c3c', 'marker': 's', 'linestyle': '-'},
     'adhoc-bin': {'color': '#c0392b', 'marker': 'p', 'linestyle': '-.'},
     'adhoc-bin-rle': {'color': '#8e44ad', 'marker': 'h', 'linestyle': '-.'},
+    'adhoc-bin-quant1': {'color': '#e67e22', 'marker': 'v', 'linestyle': '--'},
+    'adhoc-bin-quant2': {'color': '#d35400', 'marker': '<', 'linestyle': '--'},
+    'adhoc-bin-quant1-rle': {'color': '#9b59b6', 'marker': '>', 'linestyle': ':'},
+    'adhoc-bin-quant2-rle': {'color': '#6c3483', 'marker': '*', 'linestyle': ':'},
     'insitu': {'color': '#3498db', 'marker': '^', 'linestyle': '--'},
     'rgb': {'color': '#27ae60', 'marker': 'D', 'linestyle': ':'},
 }
@@ -23,6 +27,10 @@ MODE_LABELS = {
     'adhoc-plain': 'Ad-hoc (plain text)',
     'adhoc-bin': 'Ad-hoc (binary)',
     'adhoc-bin-rle': 'Ad-hoc (binary RLE)',
+    'adhoc-bin-quant1': 'Ad-hoc (binary quant L1)',
+    'adhoc-bin-quant2': 'Ad-hoc (binary quant L2)',
+    'adhoc-bin-quant1-rle': 'Ad-hoc (quant L1 + RLE)',
+    'adhoc-bin-quant2-rle': 'Ad-hoc (quant L2 + RLE)',
     'insitu': 'In-situ (grayscale)',
     'rgb': 'In-situ (RGB colormap)',
 }
@@ -94,7 +102,7 @@ def main():
     breakdown = grouped[grouped['grid_total'] == largest_grid][['mode', 'time_simulating', 'time_snapshots', 'time_sismos']]
     breakdown = breakdown.set_index('mode')
     # Reorder index to match our preferred order
-    order = [m for m in ['base', 'adhoc-plain', 'adhoc-bin', 'adhoc-bin-rle', 'insitu', 'rgb'] if m in breakdown.index]
+    order = [m for m in ['base', 'adhoc-plain', 'adhoc-bin', 'adhoc-bin-rle', 'adhoc-bin-quant1', 'adhoc-bin-quant2', 'adhoc-bin-quant1-rle', 'adhoc-bin-quant2-rle', 'insitu', 'rgb'] if m in breakdown.index]
     breakdown = breakdown.reindex(order)
     breakdown.index = [get_label(m) for m in breakdown.index]
     breakdown.plot(kind='bar', stacked=True, ax=ax, color=['#3498db', '#e74c3c', '#f39c12'])

--- a/scripts/plot_compression_benchmark.py
+++ b/scripts/plot_compression_benchmark.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Visualize compression benchmark results comparing RLE vs no compression.
+"""
+
+import argparse
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+# Color palette for compression comparison
+COMPRESSION_STYLES = {
+    'none': {'color': '#c0392b', 'marker': 's', 'linestyle': '-', 'label': 'No Compression'},
+    'rle': {'color': '#8e44ad', 'marker': 'h', 'linestyle': '-.', 'label': 'RLE'},
+    'quant1': {'color': '#e67e22', 'marker': 'v', 'linestyle': '--', 'label': 'Quant L1'},
+    'quant2': {'color': '#d35400', 'marker': '<', 'linestyle': '--', 'label': 'Quant L2'},
+    'quant1_rle': {'color': '#9b59b6', 'marker': '>', 'linestyle': ':', 'label': 'Quant L1 + RLE'},
+    'quant2_rle': {'color': '#6c3483', 'marker': '*', 'linestyle': ':', 'label': 'Quant L2 + RLE'},
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot compression benchmark results from CSV"
+    )
+    parser.add_argument(
+        "csv_file",
+        help="Path to benchmark CSV file"
+    )
+    parser.add_argument(
+        "--output-prefix", "-o",
+        default="compression",
+        help="Prefix for output files (default: compression)"
+    )
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.csv_file)
+
+    # Group by compression type and grid size, averaging multiple runs
+    grouped = df.groupby(['compression', 'grid_total']).mean(numeric_only=True).reset_index()
+
+    compressions = grouped['compression'].unique()
+
+    # Plot 1: Execution time comparison
+    fig, ax = plt.subplots(figsize=(8, 6))
+    for comp in compressions:
+        data = grouped[grouped['compression'] == comp]
+        style = COMPRESSION_STYLES.get(comp, COMPRESSION_STYLES['none'])
+        ax.plot(data['grid_total'], data['time_kernel_total'],
+                marker=style['marker'], linestyle=style['linestyle'],
+                color=style['color'], label=style['label'], linewidth=2, markersize=8)
+    ax.set_xlabel('Grid Total (elements)', fontsize=12)
+    ax.set_ylabel('Total Time (seconds)', fontsize=12)
+    ax.legend(fontsize=11)
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    filename = f'{args.output_prefix}_time_comparison.png'
+    plt.savefig(filename, dpi=150)
+    print(f"Saved {filename}")
+    plt.close()
+
+    # Plot 2: Data output comparison (log scale)
+    fig, ax = plt.subplots(figsize=(8, 6))
+    for comp in compressions:
+        data = grouped[grouped['compression'] == comp]
+        style = COMPRESSION_STYLES.get(comp, COMPRESSION_STYLES['none'])
+        ax.plot(data['grid_total'], data['total_mb'],
+                marker=style['marker'], linestyle=style['linestyle'],
+                color=style['color'], label=style['label'], linewidth=2, markersize=8)
+    ax.set_xlabel('Grid Total (elements)', fontsize=12)
+    ax.set_ylabel('Data Written (MB)', fontsize=12)
+    ax.legend(fontsize=11)
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    filename = f'{args.output_prefix}_data_comparison.png'
+    plt.savefig(filename, dpi=150)
+    print(f"Saved {filename}")
+    plt.close()
+
+    # Plot 3: Compression ratio (data reduction) - all modes vs baseline
+    fig, ax = plt.subplots(figsize=(8, 6))
+    none_data = grouped[grouped['compression'] == 'none'].sort_values('grid_total')
+
+    if len(none_data) > 0:
+        for comp in compressions:
+            if comp == 'none':
+                continue
+            comp_data = grouped[grouped['compression'] == comp].sort_values('grid_total')
+
+            if len(comp_data) > 0:
+                # Ensure both datasets have the same grid sizes
+                common_grids = set(none_data['grid_total']).intersection(set(comp_data['grid_total']))
+                none_subset = none_data[none_data['grid_total'].isin(common_grids)].sort_values('grid_total')
+                comp_subset = comp_data[comp_data['grid_total'].isin(common_grids)].sort_values('grid_total')
+
+                # Compression ratio = uncompressed / compressed (higher is better)
+                compression_ratio = none_subset['total_mb'].values / comp_subset['total_mb'].values
+
+                style = COMPRESSION_STYLES.get(comp, COMPRESSION_STYLES['none'])
+                ax.plot(none_subset['grid_total'], compression_ratio,
+                        marker=style['marker'], linestyle=style['linestyle'],
+                        color=style['color'], label=style['label'], linewidth=2, markersize=8)
+
+        ax.axhline(y=1.0, color='#95a5a6', linestyle='--', linewidth=1, label='No compression (1.0x)')
+        ax.set_xlabel('Grid Total (elements)', fontsize=12)
+        ax.set_ylabel('Compression Ratio', fontsize=12)
+        ax.legend(fontsize=11)
+        ax.grid(True, alpha=0.3)
+        plt.tight_layout()
+        filename = f'{args.output_prefix}_ratio.png'
+        plt.savefig(filename, dpi=150)
+        print(f"Saved {filename}")
+        plt.close()
+
+    # Plot 4: Snapshot time breakdown
+    fig, ax = plt.subplots(figsize=(8, 6))
+    for comp in compressions:
+        data = grouped[grouped['compression'] == comp]
+        style = COMPRESSION_STYLES.get(comp, COMPRESSION_STYLES['none'])
+        ax.plot(data['grid_total'], data['time_snapshots'],
+                marker=style['marker'], linestyle=style['linestyle'],
+                color=style['color'], label=style['label'], linewidth=2, markersize=8)
+    ax.set_xlabel('Grid Total (elements)', fontsize=12)
+    ax.set_ylabel('Snapshot Time (seconds)', fontsize=12)
+    ax.legend(fontsize=11)
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    filename = f'{args.output_prefix}_snapshot_time.png'
+    plt.savefig(filename, dpi=150)
+    print(f"Saved {filename}")
+    plt.close()
+
+    # Plot 5: Side-by-side comparison for largest grid
+    largest_grid = grouped['grid_total'].max()
+    largest_data = grouped[grouped['grid_total'] == largest_grid]
+
+    if len(largest_data) >= 2:
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
+
+        # Time comparison
+        compressions_list = largest_data['compression'].tolist()
+        times = largest_data['time_kernel_total'].tolist()
+        colors = [COMPRESSION_STYLES.get(c, COMPRESSION_STYLES['none'])['color'] for c in compressions_list]
+        labels = [COMPRESSION_STYLES.get(c, COMPRESSION_STYLES['none'])['label'] for c in compressions_list]
+
+        ax1.bar(labels, times, color=colors, alpha=0.7, edgecolor='black')
+        ax1.set_ylabel('Total Time (seconds)', fontsize=12)
+        ax1.tick_params(axis='x', rotation=45)
+        ax1.grid(True, alpha=0.3, axis='y')
+
+        # Data size comparison
+        data_sizes = largest_data['total_mb'].tolist()
+
+        ax2.bar(labels, data_sizes, color=colors, alpha=0.7, edgecolor='black')
+        ax2.set_ylabel('Data Written (MB)', fontsize=12)
+        ax2.tick_params(axis='x', rotation=45)
+        ax2.grid(True, alpha=0.3, axis='y')
+
+        plt.tight_layout()
+        filename = f'{args.output_prefix}_comparison_grid_{largest_grid}.png'
+        plt.savefig(filename, dpi=150)
+        print(f"Saved {filename}")
+        plt.close()
+
+    print("\nAll plots generated successfully!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Update benchmark_insitu_vs_adhoc.py to support quant1, quant2, quant1-rle, quant2-rle modes
- Update plot_benchmark.py with visual styles for new quantization modes
- Refactor benchmark_compression.py to support all compression variants
- Update plot_compression_benchmark.py to visualize all compression modes
- Add consistent color schemes across both benchmark types